### PR TITLE
refactor: organize module imports

### DIFF
--- a/src/icons.nim
+++ b/src/icons.nim
@@ -1,4 +1,4 @@
-import tables
+import std/tables
 
 let Icons* = {
   "ext": {
@@ -34,7 +34,7 @@ let Icons* = {
     ".rs":    "",
     ".svg":   "",
     ".mp4":   "",
-    
+
   }.toTable(),
 
   "name": {

--- a/src/main.nim
+++ b/src/main.nim
@@ -1,17 +1,6 @@
-import os
-import tables
-import strformat
-import sequtils
-import unicode
+import std/[os, tables, strformat, sequtils, unicode, options, terminal, parseopt, times]
+import icons, entry, colors
 from strutils import repeat
-import options
-import terminal
-import parseopt
-import times
-
-from icons import Icons
-from entry import Entry
-import colors
 
 var directory: string
 
@@ -90,7 +79,7 @@ proc processEntry(path: string): Option[Entry] =
   elif path.isDirectory():
     entry.icon = Icons["directories"].getOrDefault(entryParts.name, Icons["other"]["directory"])
     entry.color = blue
-  
+
   if path.isExecutable():
     if entry.icon == Icons["other"]["plainFile"]:
       entry.icon = Icons["other"]["executable"]


### PR DESCRIPTION
Hello, it's me again. 👋
Wow, how much you've progressed with this project! It's looking great. 

I'm sending you a new small contribution that will help you better organize the modules. I've also removed some `from A import B` expressions, as they are not necessary.